### PR TITLE
fix:修复管理员无法编辑帖子第一页之后的内容

### DIFF
--- a/asp/BBS/Edit.asp
+++ b/asp/BBS/Edit.asp
@@ -64,7 +64,7 @@ Else
 	  <tr>
 		<td width="604" height="500" valign="top">
 		<%
-		If Session("Title_Page")=1 Then
+		If Session("Title_Page") Then
 		
 			Notice_Text = "公告"
 			Skill_Text = "技术"


### PR DESCRIPTION
1. 修复管理员只能编辑帖子第一页的内容，无法编辑帖子第一页之后的内容。