### PR TITLE
feat: 录像上传时默认显示三位小数

### DIFF
--- a/asp/Video/Upload_Input.asp
+++ b/asp/Video/Upload_Input.asp
@@ -182,7 +182,7 @@ If Check_Result <> "Fail" Then
             return
         }
         iframe.contentDocument.querySelector("input[name='Video_3BV']").value = video.getBBBV()
-        iframe.contentDocument.querySelector("input[name='Video_Score']").value = (video.getTime() / 1000).toFixed(2)
+        iframe.contentDocument.querySelector("input[name='Video_Score']").value = (video.getTime() / 1000).toFixed(3)
         iframe.contentDocument.querySelector("input[name='Video_IsNoFrag']").checked = video.getRightClicks() === 0 && video.getDoubleClicks() === 0
     }
 


### PR DESCRIPTION
`rmv` 格式录像是后面加的，当时没有考虑到有三位小数的情况，现在将所有录像上传时填写的时间都改为三位小数，用户如果有特殊需求可以自行修改。